### PR TITLE
Refactor D3.js skill from React to Svelte 5

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: d3-viz
-description: Creating interactive data visualisations using d3.js. This skill should be used when creating custom charts, graphs, network diagrams, geographic visualisations, or any complex SVG-based data visualisation that requires fine-grained control over visual elements, transitions, or interactions. Use this for bespoke visualisations beyond standard charting libraries, whether in React, Vue, Svelte, vanilla JavaScript, or any other environment.
+description: Creating interactive data visualisations using d3.js with Svelte 5. This skill should be used when creating custom charts, graphs, network diagrams, geographic visualisations, or any complex SVG-based data visualisation that requires fine-grained control over visual elements, transitions, or interactions. Use this for bespoke visualisations beyond standard charting libraries in Svelte 5 applications.
 ---
 
-# D3.js Visualisation
+# D3.js Visualisation with Svelte 5
 
 ## Overview
 
-This skill provides guidance for creating sophisticated, interactive data visualisations using d3.js. D3.js (Data-Driven Documents) excels at binding data to DOM elements and applying data-driven transformations to create custom, publication-quality visualisations with precise control over every visual element. The techniques work across any JavaScript environment, including vanilla JavaScript, React, Vue, Svelte, and other frameworks.
+This skill provides guidance for creating sophisticated, interactive data visualisations using d3.js with Svelte 5. D3.js (Data-Driven Documents) excels at binding data to DOM elements and applying data-driven transformations to create custom, publication-quality visualisations with precise control over every visual element. The techniques leverage Svelte 5's runes system (`$state`, `$effect`, `$props`) for reactive data binding.
 
 ## When to use d3.js
 
@@ -43,210 +43,268 @@ All modules (scales, axes, shapes, transitions, etc.) are accessible through the
 
 ### 2. Choose the integration pattern
 
-**Pattern A: Direct DOM manipulation (recommended for most cases)**
-Use d3 to select DOM elements and manipulate them imperatively. This works in any JavaScript environment:
+**Pattern A: Direct DOM manipulation with $effect (recommended for most cases)**
+Use d3 to select DOM elements and manipulate them imperatively within Svelte 5's `$effect` rune:
 
-```javascript
-function drawChart(data) {
-  if (!data || data.length === 0) return;
+```svelte
+<script>
+  import * as d3 from 'd3';
 
-  const svg = d3.select('#chart'); // Select by ID, class, or DOM element
+  let { data = [] } = $props();
+  let svgElement = $state();
 
-  // Clear previous content
-  svg.selectAll("*").remove();
+  $effect(() => {
+    if (!data || data.length === 0 || !svgElement) return;
 
-  // Set up dimensions
-  const width = 800;
-  const height = 400;
-  const margin = { top: 20, right: 30, bottom: 40, left: 50 };
+    const svg = d3.select(svgElement);
+    svg.selectAll("*").remove(); // Clear previous content
 
-  // Create scales, axes, and draw visualisation
-  // ... d3 code here ...
-}
+    // Set up dimensions
+    const width = 800;
+    const height = 400;
+    const margin = { top: 20, right: 30, bottom: 40, left: 50 };
 
-// Call when data changes
-drawChart(myData);
+    // Create scales, axes, and draw visualisation
+    // ... d3 code here ...
+  });
+</script>
+
+<svg bind:this={svgElement} width="800" height="400"></svg>
 ```
 
-**Pattern B: Declarative rendering (for frameworks with templating)**
-Use d3 for data calculations (scales, layouts) but render elements via your framework:
+**Pattern B: Declarative rendering with Svelte templates**
+Use d3 for data calculations (scales, layouts) but render elements via Svelte's template syntax:
 
-```javascript
-function getChartElements(data) {
-  const xScale = d3.scaleLinear()
-    .domain([0, d3.max(data, d => d.value)])
-    .range([0, 400]);
+```svelte
+<script>
+  import * as d3 from 'd3';
 
-  return data.map((d, i) => ({
-    x: 50,
-    y: i * 30,
-    width: xScale(d.value),
-    height: 25
-  }));
-}
+  let { data = [] } = $props();
 
-// In React: {getChartElements(data).map((d, i) => <rect key={i} {...d} fill="steelblue" />)}
-// In Vue: v-for directive over the returned array
-// In vanilla JS: Create elements manually from the returned data
+  let chartElements = $derived(() => {
+    const xScale = d3.scaleLinear()
+      .domain([0, d3.max(data, d => d.value)])
+      .range([0, 400]);
+
+    return data.map((d, i) => ({
+      x: 50,
+      y: i * 30,
+      width: xScale(d.value),
+      height: 25
+    }));
+  });
+</script>
+
+<svg width="500" height="{data.length * 30}">
+  {#each chartElements as element, i}
+    <rect
+      x={element.x}
+      y={element.y}
+      width={element.width}
+      height={element.height}
+      fill="steelblue"
+    />
+  {/each}
+</svg>
 ```
 
-Use Pattern A for complex visualisations with transitions, interactions, or when leveraging d3's full capabilities. Use Pattern B for simpler visualisations or when your framework prefers declarative rendering.
+Use Pattern A for complex visualisations with transitions, interactions, or when leveraging d3's full capabilities. Use Pattern B for simpler visualisations where Svelte's declarative rendering is preferred.
 
 ### 3. Structure the visualisation code
 
-Follow this standard structure in your drawing function:
+Follow this standard structure in your Svelte 5 component:
 
-```javascript
-function drawVisualization(data) {
-  if (!data || data.length === 0) return;
+```svelte
+<script>
+  import * as d3 from 'd3';
 
-  const svg = d3.select('#chart'); // Or pass a selector/element
-  svg.selectAll("*").remove(); // Clear previous render
+  let { data = [] } = $props();
+  let svgElement = $state();
 
-  // 1. Define dimensions
-  const width = 800;
-  const height = 400;
-  const margin = { top: 20, right: 30, bottom: 40, left: 50 };
-  const innerWidth = width - margin.left - margin.right;
-  const innerHeight = height - margin.top - margin.bottom;
+  $effect(() => {
+    if (!data || data.length === 0 || !svgElement) return;
 
-  // 2. Create main group with margins
-  const g = svg.append("g")
-    .attr("transform", `translate(${margin.left},${margin.top})`);
+    const svg = d3.select(svgElement);
+    svg.selectAll("*").remove(); // Clear previous render
 
-  // 3. Create scales
-  const xScale = d3.scaleLinear()
-    .domain([0, d3.max(data, d => d.x)])
-    .range([0, innerWidth]);
+    // 1. Define dimensions
+    const width = 800;
+    const height = 400;
+    const margin = { top: 20, right: 30, bottom: 40, left: 50 };
+    const innerWidth = width - margin.left - margin.right;
+    const innerHeight = height - margin.top - margin.bottom;
 
-  const yScale = d3.scaleLinear()
-    .domain([0, d3.max(data, d => d.y)])
-    .range([innerHeight, 0]); // Note: inverted for SVG coordinates
+    // 2. Create main group with margins
+    const g = svg.append("g")
+      .attr("transform", `translate(${margin.left},${margin.top})`);
 
-  // 4. Create and append axes
-  const xAxis = d3.axisBottom(xScale);
-  const yAxis = d3.axisLeft(yScale);
+    // 3. Create scales
+    const xScale = d3.scaleLinear()
+      .domain([0, d3.max(data, d => d.x)])
+      .range([0, innerWidth]);
 
-  g.append("g")
-    .attr("transform", `translate(0,${innerHeight})`)
-    .call(xAxis);
+    const yScale = d3.scaleLinear()
+      .domain([0, d3.max(data, d => d.y)])
+      .range([innerHeight, 0]); // Note: inverted for SVG coordinates
 
-  g.append("g")
-    .call(yAxis);
+    // 4. Create and append axes
+    const xAxis = d3.axisBottom(xScale);
+    const yAxis = d3.axisLeft(yScale);
 
-  // 5. Bind data and create visual elements
-  g.selectAll("circle")
-    .data(data)
-    .join("circle")
-    .attr("cx", d => xScale(d.x))
-    .attr("cy", d => yScale(d.y))
-    .attr("r", 5)
-    .attr("fill", "steelblue");
-}
+    g.append("g")
+      .attr("transform", `translate(0,${innerHeight})`)
+      .call(xAxis);
 
-// Call when data changes
-drawVisualization(myData);
+    g.append("g")
+      .call(yAxis);
+
+    // 5. Bind data and create visual elements
+    g.selectAll("circle")
+      .data(data)
+      .join("circle")
+      .attr("cx", d => xScale(d.x))
+      .attr("cy", d => yScale(d.y))
+      .attr("r", 5)
+      .attr("fill", "steelblue");
+  });
+</script>
+
+<svg bind:this={svgElement} width="800" height="400"></svg>
 ```
 
 ### 4. Implement responsive sizing
 
-Make visualisations responsive to container size:
+Make visualisations responsive to container size using Svelte 5:
 
-```javascript
-function setupResponsiveChart(containerId, data) {
-  const container = document.getElementById(containerId);
-  const svg = d3.select(`#${containerId}`).append('svg');
+```svelte
+<script>
+  import * as d3 from 'd3';
+  import { onMount } from 'svelte';
 
-  function updateChart() {
-    const { width, height } = container.getBoundingClientRect();
-    svg.attr('width', width).attr('height', height);
+  let { data = [] } = $props();
 
-    // Redraw visualisation with new dimensions
-    drawChart(data, svg, width, height);
-  }
+  let containerElement = $state();
+  let svgElement = $state();
+  let width = $state(800);
+  let height = $state(400);
 
-  // Update on initial load
-  updateChart();
+  $effect(() => {
+    if (!containerElement) return;
 
-  // Update on window resize
-  window.addEventListener('resize', updateChart);
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      width = entry.contentRect.width;
+      height = entry.contentRect.height;
+    });
 
-  // Return cleanup function
-  return () => window.removeEventListener('resize', updateChart);
-}
+    observer.observe(containerElement);
 
-// Usage:
-// const cleanup = setupResponsiveChart('chart-container', myData);
-// cleanup(); // Call when component unmounts or element removed
-```
-
-Or use ResizeObserver for more direct container monitoring:
-
-```javascript
-function setupResponsiveChartWithObserver(svgElement, data) {
-  const observer = new ResizeObserver(() => {
-    const { width, height } = svgElement.getBoundingClientRect();
-    d3.select(svgElement)
-      .attr('width', width)
-      .attr('height', height);
-
-    // Redraw visualisation
-    drawChart(data, d3.select(svgElement), width, height);
+    return () => observer.disconnect();
   });
 
-  observer.observe(svgElement.parentElement);
-  return () => observer.disconnect();
-}
+  $effect(() => {
+    if (!data || data.length === 0 || !svgElement) return;
+
+    const svg = d3.select(svgElement);
+    svg.selectAll("*").remove();
+
+    // Use reactive width and height for dimensions
+    const margin = { top: 20, right: 30, bottom: 40, left: 50 };
+    const innerWidth = width - margin.left - margin.right;
+    const innerHeight = height - margin.top - margin.bottom;
+
+    // Draw visualisation with current dimensions...
+  });
+</script>
+
+<div bind:this={containerElement} class="chart-container" style="width: 100%; height: 100%;">
+  <svg bind:this={svgElement} {width} {height}></svg>
+</div>
+```
+
+Or use a simpler approach with window resize:
+
+```svelte
+<script>
+  import * as d3 from 'd3';
+
+  let { data = [] } = $props();
+
+  let svgElement = $state();
+  let innerWidth = $state(typeof window !== 'undefined' ? window.innerWidth : 800);
+
+  $effect(() => {
+    if (typeof window === 'undefined') return;
+
+    const handleResize = () => {
+      innerWidth = window.innerWidth;
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  });
+
+  $effect(() => {
+    if (!data || data.length === 0 || !svgElement) return;
+    // Redraw chart using innerWidth...
+  });
+</script>
 ```
 
 ## Common visualisation patterns
 
 ### Bar chart
 
-```javascript
-function drawBarChart(data, svgElement) {
-  if (!data || data.length === 0) return;
+```svelte
+<script>
+  import * as d3 from 'd3';
 
-  const svg = d3.select(svgElement);
-  svg.selectAll("*").remove();
+  let { data = [] } = $props();
+  let svgElement = $state();
 
-  const width = 800;
-  const height = 400;
-  const margin = { top: 20, right: 30, bottom: 40, left: 50 };
-  const innerWidth = width - margin.left - margin.right;
-  const innerHeight = height - margin.top - margin.bottom;
+  $effect(() => {
+    if (!data || data.length === 0 || !svgElement) return;
 
-  const g = svg.append("g")
-    .attr("transform", `translate(${margin.left},${margin.top})`);
+    const svg = d3.select(svgElement);
+    svg.selectAll("*").remove();
 
-  const xScale = d3.scaleBand()
-    .domain(data.map(d => d.category))
-    .range([0, innerWidth])
-    .padding(0.1);
+    const width = 800;
+    const height = 400;
+    const margin = { top: 20, right: 30, bottom: 40, left: 50 };
+    const innerWidth = width - margin.left - margin.right;
+    const innerHeight = height - margin.top - margin.bottom;
 
-  const yScale = d3.scaleLinear()
-    .domain([0, d3.max(data, d => d.value)])
-    .range([innerHeight, 0]);
+    const g = svg.append("g")
+      .attr("transform", `translate(${margin.left},${margin.top})`);
 
-  g.append("g")
-    .attr("transform", `translate(0,${innerHeight})`)
-    .call(d3.axisBottom(xScale));
+    const xScale = d3.scaleBand()
+      .domain(data.map(d => d.category))
+      .range([0, innerWidth])
+      .padding(0.1);
 
-  g.append("g")
-    .call(d3.axisLeft(yScale));
+    const yScale = d3.scaleLinear()
+      .domain([0, d3.max(data, d => d.value)])
+      .range([innerHeight, 0]);
 
-  g.selectAll("rect")
-    .data(data)
-    .join("rect")
-    .attr("x", d => xScale(d.category))
-    .attr("y", d => yScale(d.value))
-    .attr("width", xScale.bandwidth())
-    .attr("height", d => innerHeight - yScale(d.value))
-    .attr("fill", "steelblue");
-}
+    g.append("g")
+      .attr("transform", `translate(0,${innerHeight})`)
+      .call(d3.axisBottom(xScale));
 
-// Usage:
-// drawBarChart(myData, document.getElementById('chart'));
+    g.append("g")
+      .call(d3.axisLeft(yScale));
+
+    g.selectAll("rect")
+      .data(data)
+      .join("rect")
+      .attr("x", d => xScale(d.category))
+      .attr("y", d => yScale(d.value))
+      .attr("width", xScale.bandwidth())
+      .attr("height", d => innerHeight - yScale(d.value))
+      .attr("fill", "steelblue");
+  });
+</script>
+
+<svg bind:this={svgElement} width="800" height="400"></svg>
 ```
 
 ### Line chart
@@ -786,7 +844,7 @@ g.selectAll(".tick line")
 **Issue**: Transitions not working
 - Call `.transition()` before attribute changes
 - Ensure elements have unique keys for proper data binding
-- Check that useEffect dependencies include all changing data
+- Check that $effect dependencies are correctly tracked (Svelte 5 auto-tracks reactive state)
 
 **Issue**: Responsive sizing not working
 - Use ResizeObserver or window resize listener
@@ -809,12 +867,12 @@ Contains detailed reference materials:
 
 ### assets/
 
-Contains boilerplate templates:
+Contains boilerplate Svelte 5 templates:
 
-- `chart-template.js` - Starter template for basic chart
-- `interactive-template.js` - Template with tooltips, zoom, and interactions
+- `chart-template.svelte` - Starter template for basic chart using Svelte 5 runes
+- `interactive-template.svelte` - Template with tooltips, zoom, and interactions using Svelte 5
 - `sample-data.json` - Example datasets for testing
 
-These templates work with vanilla JavaScript, React, Vue, Svelte, or any other JavaScript environment. Adapt them as needed for your specific framework.
+These templates are built for Svelte 5 and use the modern runes syntax (`$state`, `$effect`, `$props`). Import them directly into your Svelte 5 application.
 
 To use these resources, read the relevant files when detailed guidance is needed for specific visualisation types or patterns.

--- a/assets/chart-template.svelte
+++ b/assets/chart-template.svelte
@@ -1,51 +1,52 @@
-import { useEffect, useRef, useState } from 'react';
-import * as d3 from 'd3';
+<script>
+  import * as d3 from 'd3';
 
-function BasicChart({ data }) {
-  const svgRef = useRef();
-  
-  useEffect(() => {
-    if (!data || data.length === 0) return;
-    
+  let { data = [] } = $props();
+
+  let svgElement = $state();
+
+  $effect(() => {
+    if (!data || data.length === 0 || !svgElement) return;
+
     // Select SVG element
-    const svg = d3.select(svgRef.current);
+    const svg = d3.select(svgElement);
     svg.selectAll("*").remove(); // Clear previous content
-    
+
     // Define dimensions and margins
     const width = 800;
     const height = 400;
     const margin = { top: 20, right: 30, bottom: 40, left: 50 };
     const innerWidth = width - margin.left - margin.right;
     const innerHeight = height - margin.top - margin.bottom;
-    
+
     // Create main group with margins
     const g = svg.append("g")
       .attr("transform", `translate(${margin.left},${margin.top})`);
-    
+
     // Create scales
     const xScale = d3.scaleBand()
       .domain(data.map(d => d.label))
       .range([0, innerWidth])
       .padding(0.1);
-    
+
     const yScale = d3.scaleLinear()
       .domain([0, d3.max(data, d => d.value)])
       .range([innerHeight, 0])
       .nice();
-    
+
     // Create and append axes
     const xAxis = d3.axisBottom(xScale);
     const yAxis = d3.axisLeft(yScale);
-    
+
     g.append("g")
       .attr("class", "x-axis")
       .attr("transform", `translate(0,${innerHeight})`)
       .call(xAxis);
-    
+
     g.append("g")
       .attr("class", "y-axis")
       .call(yAxis);
-    
+
     // Bind data and create visual elements (bars in this example)
     g.selectAll("rect")
       .data(data)
@@ -55,7 +56,7 @@ function BasicChart({ data }) {
       .attr("width", xScale.bandwidth())
       .attr("height", d => innerHeight - yScale(d.value))
       .attr("fill", "steelblue");
-    
+
     // Optional: Add axis labels
     g.append("text")
       .attr("class", "axis-label")
@@ -63,7 +64,7 @@ function BasicChart({ data }) {
       .attr("y", innerHeight + margin.bottom - 5)
       .attr("text-anchor", "middle")
       .text("Category");
-    
+
     g.append("text")
       .attr("class", "axis-label")
       .attr("transform", "rotate(-90)")
@@ -71,36 +72,14 @@ function BasicChart({ data }) {
       .attr("y", -margin.left + 15)
       .attr("text-anchor", "middle")
       .text("Value");
-    
-  }, [data]);
-  
-  return (
-    <div className="chart-container">
-      <svg 
-        ref={svgRef} 
-        width="800" 
-        height="400"
-        style={{ border: '1px solid #ddd' }}
-      />
-    </div>
-  );
-}
+  });
+</script>
 
-// Example usage
-export default function App() {
-  const sampleData = [
-    { label: 'A', value: 30 },
-    { label: 'B', value: 80 },
-    { label: 'C', value: 45 },
-    { label: 'D', value: 60 },
-    { label: 'E', value: 20 },
-    { label: 'F', value: 90 }
-  ];
-  
-  return (
-    <div className="p-8">
-      <h1 className="text-2xl font-bold mb-4">Basic D3.js Chart</h1>
-      <BasicChart data={sampleData} />
-    </div>
-  );
-}
+<div class="chart-container">
+  <svg
+    bind:this={svgElement}
+    width="800"
+    height="400"
+    style="border: 1px solid #ddd;"
+  ></svg>
+</div>

--- a/assets/interactive-template.svelte
+++ b/assets/interactive-template.svelte
@@ -1,67 +1,68 @@
-import { useEffect, useRef, useState } from 'react';
-import * as d3 from 'd3';
+<script>
+  import * as d3 from 'd3';
 
-function InteractiveChart({ data }) {
-  const svgRef = useRef();
-  const tooltipRef = useRef();
-  const [selectedPoint, setSelectedPoint] = useState(null);
-  
-  useEffect(() => {
-    if (!data || data.length === 0) return;
-    
-    const svg = d3.select(svgRef.current);
+  let { data = [] } = $props();
+
+  let svgElement = $state();
+  let tooltipElement = $state();
+  let selectedPoint = $state(null);
+
+  $effect(() => {
+    if (!data || data.length === 0 || !svgElement) return;
+
+    const svg = d3.select(svgElement);
     svg.selectAll("*").remove();
-    
+
     // Dimensions
     const width = 800;
     const height = 500;
     const margin = { top: 20, right: 30, bottom: 40, left: 50 };
     const innerWidth = width - margin.left - margin.right;
     const innerHeight = height - margin.top - margin.bottom;
-    
+
     // Create main group
     const g = svg.append("g")
       .attr("transform", `translate(${margin.left},${margin.top})`);
-    
+
     // Scales
     const xScale = d3.scaleLinear()
       .domain([0, d3.max(data, d => d.x)])
       .range([0, innerWidth])
       .nice();
-    
+
     const yScale = d3.scaleLinear()
       .domain([0, d3.max(data, d => d.y)])
       .range([innerHeight, 0])
       .nice();
-    
+
     const sizeScale = d3.scaleSqrt()
       .domain([0, d3.max(data, d => d.size || 10)])
       .range([3, 20]);
-    
+
     const colourScale = d3.scaleOrdinal(d3.schemeCategory10);
-    
+
     // Add zoom behaviour
     const zoom = d3.zoom()
       .scaleExtent([0.5, 10])
       .on("zoom", (event) => {
         g.attr("transform", `translate(${margin.left + event.transform.x},${margin.top + event.transform.y}) scale(${event.transform.k})`);
       });
-    
+
     svg.call(zoom);
-    
+
     // Axes
     const xAxis = d3.axisBottom(xScale);
     const yAxis = d3.axisLeft(yScale);
-    
-    const xAxisGroup = g.append("g")
+
+    g.append("g")
       .attr("class", "x-axis")
       .attr("transform", `translate(0,${innerHeight})`)
       .call(xAxis);
-    
-    const yAxisGroup = g.append("g")
+
+    g.append("g")
       .attr("class", "y-axis")
       .call(yAxis);
-    
+
     // Grid lines
     g.append("g")
       .attr("class", "grid")
@@ -69,7 +70,7 @@ function InteractiveChart({ data }) {
       .call(d3.axisLeft(yScale)
         .tickSize(-innerWidth)
         .tickFormat(""));
-    
+
     g.append("g")
       .attr("class", "grid")
       .attr("opacity", 0.1)
@@ -77,10 +78,10 @@ function InteractiveChart({ data }) {
       .call(d3.axisBottom(xScale)
         .tickSize(-innerHeight)
         .tickFormat(""));
-    
+
     // Tooltip
-    const tooltip = d3.select(tooltipRef.current);
-    
+    const tooltip = d3.select(tooltipElement);
+
     // Data points
     const circles = g.selectAll("circle")
       .data(data)
@@ -93,7 +94,7 @@ function InteractiveChart({ data }) {
       .attr("stroke-width", 2)
       .attr("opacity", 0.7)
       .style("cursor", "pointer");
-    
+
     // Hover interactions
     circles
       .on("mouseover", function(event, d) {
@@ -103,7 +104,7 @@ function InteractiveChart({ data }) {
           .duration(200)
           .attr("opacity", 1)
           .attr("stroke-width", 3);
-        
+
         // Show tooltip
         tooltip
           .style("display", "block")
@@ -129,7 +130,7 @@ function InteractiveChart({ data }) {
           .duration(200)
           .attr("opacity", 0.7)
           .attr("stroke-width", 2);
-        
+
         // Hide tooltip
         tooltip.style("display", "none");
       })
@@ -139,10 +140,10 @@ function InteractiveChart({ data }) {
         d3.select(this)
           .attr("stroke", "#000")
           .attr("stroke-width", 3);
-        
-        setSelectedPoint(d);
+
+        selectedPoint = d;
       });
-    
+
     // Add transition on initial render
     circles
       .attr("r", 0)
@@ -150,7 +151,7 @@ function InteractiveChart({ data }) {
       .duration(800)
       .delay((d, i) => i * 20)
       .attr("r", d => sizeScale(d.size || 10));
-    
+
     // Axis labels
     g.append("text")
       .attr("class", "axis-label")
@@ -159,7 +160,7 @@ function InteractiveChart({ data }) {
       .attr("text-anchor", "middle")
       .style("font-size", "14px")
       .text("X Axis");
-    
+
     g.append("text")
       .attr("class", "axis-label")
       .attr("transform", "rotate(-90)")
@@ -168,60 +169,35 @@ function InteractiveChart({ data }) {
       .attr("text-anchor", "middle")
       .style("font-size", "14px")
       .text("Y Axis");
-    
-  }, [data]);
-  
-  return (
-    <div className="relative">
-      <svg 
-        ref={svgRef} 
-        width="800" 
-        height="500"
-        style={{ border: '1px solid #ddd', cursor: 'grab' }}
-      />
-      <div
-        ref={tooltipRef}
-        style={{
-          position: 'absolute',
-          display: 'none',
-          padding: '10px',
-          background: 'white',
-          border: '1px solid #ddd',
-          borderRadius: '4px',
-          pointerEvents: 'none',
-          boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
-          fontSize: '13px',
-          zIndex: 1000
-        }}
-      />
-      {selectedPoint && (
-        <div className="mt-4 p-4 bg-blue-50 rounded border border-blue-200">
-          <h3 className="font-bold mb-2">Selected Point</h3>
-          <pre className="text-sm">{JSON.stringify(selectedPoint, null, 2)}</pre>
-        </div>
-      )}
-    </div>
-  );
-}
+  });
+</script>
 
-// Example usage
-export default function App() {
-  const sampleData = Array.from({ length: 50 }, (_, i) => ({
-    id: i,
-    label: `Point ${i + 1}`,
-    x: Math.random() * 100,
-    y: Math.random() * 100,
-    size: Math.random() * 30 + 5,
-    category: ['A', 'B', 'C', 'D'][Math.floor(Math.random() * 4)]
-  }));
-  
-  return (
-    <div className="p-8">
-      <h1 className="text-2xl font-bold mb-2">Interactive D3.js Chart</h1>
-      <p className="text-gray-600 mb-4">
-        Hover over points for details. Click to select. Scroll to zoom. Drag to pan.
-      </p>
-      <InteractiveChart data={sampleData} />
+<div class="relative">
+  <svg
+    bind:this={svgElement}
+    width="800"
+    height="500"
+    style="border: 1px solid #ddd; cursor: grab;"
+  ></svg>
+  <div
+    bind:this={tooltipElement}
+    style="
+      position: absolute;
+      display: none;
+      padding: 10px;
+      background: white;
+      border: 1px solid #ddd;
+      border-radius: 4px;
+      pointer-events: none;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+      font-size: 13px;
+      z-index: 1000;
+    "
+  ></div>
+  {#if selectedPoint}
+    <div class="mt-4 p-4 bg-blue-50 rounded border border-blue-200">
+      <h3 class="font-bold mb-2">Selected Point</h3>
+      <pre class="text-sm">{JSON.stringify(selectedPoint, null, 2)}</pre>
     </div>
-  );
-}
+  {/if}
+</div>


### PR DESCRIPTION
- Replace React JSX templates with Svelte 5 components using runes
- Update SKILL.md documentation to use Svelte 5 syntax ($state, $effect, $props)
- Convert chart-template.jsx to chart-template.svelte
- Convert interactive-template.jsx to interactive-template.svelte
- Update integration patterns and examples for Svelte 5