### PR TITLE
feat: add marketplace metadata for /plugin compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,65 @@
+# D3.js Visualization Skill for Claude
+
+A Claude Code skill for creating interactive data visualizations using [D3.js](https://d3js.org/).
+
+## Installation
+
+### Via Claude Code Plugin Marketplace
+
+```
+/plugin marketplace add chrisvoncsefalvay/claude-d3js-skill
+```
+
+### Manual Installation
+
+```bash
+cd ~/.claude/skills
+git clone https://github.com/chrisvoncsefalvay/claude-d3js-skill.git d3-viz
+```
+
+## Usage
+
+Once installed, simply ask Claude to create data visualizations:
+
+- *"Create a bar chart showing quarterly sales data"*
+- *"Generate a force-directed network graph"*
+- *"Build an interactive line chart with tooltips"*
+- *"Make a heatmap of the correlation matrix"*
+
+## What's Included
+
+- **SKILL.md** - Main skill definition with comprehensive D3.js guidance
+- **assets/** - Boilerplate templates for common chart types
+- **references/** - Detailed reference documentation for D3.js patterns
+
+## Capabilities
+
+This skill enables Claude to create:
+
+| Visualization | Description |
+|---------------|-------------|
+| Bar Charts | Vertical/horizontal bar charts with scales |
+| Line Charts | Time series and continuous data |
+| Scatter Plots | Two-variable relationships |
+| Pie Charts | Part-to-whole relationships |
+| Chord Diagrams | Circular flow relationships |
+| Heatmaps | Matrix visualizations with color encoding |
+| Force-Directed Networks | Node-link diagrams |
+
+## Features
+
+- ✅ D3.js v7 best practices
+- ✅ Responsive sizing
+- ✅ Interactive tooltips
+- ✅ Zoom and pan
+- ✅ Smooth transitions
+- ✅ Accessibility support
+- ✅ Works with React, Vue, Svelte, or vanilla JS
+
+## License
+
+MIT
+
+## Author
+
+Chris von Csefalvay

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,18 @@
 ---
 name: d3-viz
 description: Creating interactive data visualisations using d3.js. This skill should be used when creating custom charts, graphs, network diagrams, geographic visualisations, or any complex SVG-based data visualisation that requires fine-grained control over visual elements, transitions, or interactions. Use this for bespoke visualisations beyond standard charting libraries, whether in React, Vue, Svelte, vanilla JavaScript, or any other environment.
+version: 1.0.0
+author: Chris von Csefalvay
+category: data
+tags:
+  - d3js
+  - visualization
+  - charts
+  - svg
+  - interactive
+license: MIT
+repository: https://github.com/chrisvoncsefalvay/claude-d3js-skill
+homepage: https://github.com/chrisvoncsefalvay/claude-d3js-skill
 ---
 
 # D3.js Visualisation


### PR DESCRIPTION
## Summary

This PR adds the required YAML frontmatter fields to make the skill compatible with the Claude Code skill marketplace.

## Changes

Added the following fields to SKILL.md frontmatter:

| Field | Value |
|-------|-------|
| version | 1.0.0 |
| author | Chris von Csefalvay |
| category | data |
| tags | d3js, visualization, charts, svg, interactive |
| license | MIT |
| repository | GitHub URL |
| homepage | GitHub URL |

Also added a README.md with:
- Installation instructions (marketplace and manual)
- Usage examples
- Feature list

## Why?

The [Token-Eater/skills-marketplace](https://github.com/Token-Eater/skills-marketplace) community marketplace requires these fields for skill discovery and installation.

After this change, users can install the skill via:

```
/plugin marketplace add chrisvoncsefalvay/claude-d3js-skill
```

## References

- [Creating Skills Guide](https://github.com/Token-Eater/skills-marketplace/blob/main/docs/creating-skills.md)
- [Skills Marketplace](https://github.com/Token-Eater/skills-marketplace)
